### PR TITLE
Fixed aggregate root serialized value binding

### DIFF
--- a/src/PdoSnapshotStore.php
+++ b/src/PdoSnapshotStore.php
@@ -122,7 +122,7 @@ EOT;
                 $statement->bindValue(++$position, $snapshot->aggregateType());
                 $statement->bindValue(++$position, $snapshot->lastVersion(), PDO::PARAM_INT);
                 $statement->bindValue(++$position, $snapshot->createdAt()->format('Y-m-d\TH:i:s.u'));
-                $statement->bindValue(++$position, $this->serializer->serialize($snapshot->aggregateRoot()));
+                $statement->bindValue(++$position, $this->serializer->serialize($snapshot->aggregateRoot()), PDO::PARAM_LOB);
             }
             $statements[] = $statement;
         }

--- a/tests/Container/PdoSnapshotStoreFactoryTest.php
+++ b/tests/Container/PdoSnapshotStoreFactoryTest.php
@@ -71,7 +71,17 @@ class PdoSnapshotStoreFactoryTest extends TestCase
 
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
         $container->get('config')->willReturn($config)->shouldBeCalled();
-        $container->get('serializer_servicename')->willReturn(new CallbackSerializer(function() {}, function() {}))->shouldBeCalled();
+        $container
+            ->get('serializer_servicename')
+            ->willReturn(
+                new CallbackSerializer(
+                    function () {
+                    },
+                    function () {
+                    }
+                )
+            )
+            ->shouldBeCalled();
 
         $factory = new PdoSnapshotStoreFactory();
         $snapshotStore = $factory($container->reveal());

--- a/tests/Mock/AggregateRoot.php
+++ b/tests/Mock/AggregateRoot.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * This file is part of the prooph/pdo-snapshot-store.
+ * (c) 2016-2017 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\SnapshotStore\Pdo\Mock;
+
+class AggregateRoot
+{
+}

--- a/tests/PdoSnapshotStoreTest.php
+++ b/tests/PdoSnapshotStoreTest.php
@@ -16,6 +16,7 @@ use PDO;
 use PHPUnit\Framework\TestCase;
 use Prooph\SnapshotStore\Pdo\PdoSnapshotStore;
 use Prooph\SnapshotStore\Snapshot;
+use ProophTest\SnapshotStore\Pdo\Mock\AggregateRoot;
 
 class PdoSnapshotStoreTest extends TestCase
 {
@@ -35,8 +36,7 @@ class PdoSnapshotStoreTest extends TestCase
     public function it_saves_and_reads()
     {
         $aggregateType = 'baz';
-        $aggregateRoot = new \stdClass();
-        $aggregateRoot->foo = 'bar';
+        $aggregateRoot = new AggregateRoot();
 
         $time = (string) microtime(true);
         if (false === strpos($time, '.')) {


### PR DESCRIPTION
Not specifying the data type in the bind for PostgreSQL for serialized objects other than \stdClass will result in a fail