### PR TITLE
Restructure docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -127,11 +127,10 @@ cache:
 before_script:
   - mkdir -p "$HOME/.php-cs-fixer"
   - phpenv config-rm xdebug.ini
-  - VENDOR=$(echo $DB | cut -d'_' -f 1)
-  - if [[ $DB == 'mysql_5.7' ]]; then bash .travis.install-mysql-5.7.sh; fi
-  - if [[ $DB == 'mariadb_10.2' ]]; then bash .travis.install-mariadb-10.2.sh; fi
-  - if [[ $DRIVER == 'pdo_mysql' ]]; then mysql -e 'create database snapshot_tests;'; fi
-  - if [[ $DRIVER == 'pdo_pgsql' ]]; then psql -c 'create database snapshot_tests;' -U postgres; fi
+    - VENDOR=$(echo $DB | cut -d'_' -f 1)
+    - if [[ $DB == 'mysql_5.7' ]]; then bash .travis.install-mysql-5.7.sh; fi
+    - if [[ $DRIVER == 'pdo_mysql' ]]; then  mysql -e 'create database snapshot_tests;'; fi
+    - if [[ $DRIVER == 'pdo_pgsql' ]]; then psql -c 'create database snapshot_tests;' -U postgres; fi
   - composer self-update
   - composer update --prefer-dist $DEPENDENCIES
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -127,10 +127,10 @@ cache:
 before_script:
   - mkdir -p "$HOME/.php-cs-fixer"
   - phpenv config-rm xdebug.ini
-    - VENDOR=$(echo $DB | cut -d'_' -f 1)
-    - if [[ $DB == 'mysql_5.7' ]]; then bash .travis.install-mysql-5.7.sh; fi
-    - if [[ $DRIVER == 'pdo_mysql' ]]; then  mysql -e 'create database snapshot_tests;'; fi
-    - if [[ $DRIVER == 'pdo_pgsql' ]]; then psql -c 'create database snapshot_tests;' -U postgres; fi
+  - VENDOR=$(echo $DB | cut -d'_' -f 1)
+  - if [[ $DB == 'mysql_5.7' ]]; then bash .travis.install-mysql-5.7.sh; fi
+  - if [[ $DRIVER == 'pdo_mysql' ]]; then  mysql -e 'create database snapshot_tests;'; fi
+  - if [[ $DRIVER == 'pdo_pgsql' ]]; then psql -c 'create database snapshot_tests;' -U postgres; fi
   - composer self-update
   - composer update --prefer-dist $DEPENDENCIES
 

--- a/composer.json
+++ b/composer.json
@@ -65,10 +65,12 @@
     "scripts": {
         "check": [
             "@cs",
-            "@test"
+            "@test",
+            "@docheader"
         ],
         "cs": "php-cs-fixer fix -v --diff --dry-run",
         "cs-fix": "php-cs-fixer fix -v --diff",
+        "docheader": "docheader check src/ tests/",
         "test": "phpunit"
     }
 }

--- a/docs/bookdown.json
+++ b/docs/bookdown.json
@@ -1,10 +1,11 @@
 {
-  "title": "Prooph PDO SnapshotStore",
+  "title": "PDO Snapshot Store",
   "content": [
-    {"intro": "../README.md"},
-    {"snapshots": "setup.md"},
+    {"intro": "introduction.md"},
     {"interop_factories": "interop_factories.md"}
   ],
+  "tocDepth": 1,
+  "numbering": false,
   "target": "./html",
   "template": "../vendor/prooph/bookdown-template/templates/main.php"
 }

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,4 +1,14 @@
-# Setup
+# Overview
+
+PDO implementation of snapshot store
+
+## Installation
+
+```bash
+composer require prooph/pdo-snapshot-store
+```
+
+## Setup
 
 The PDO SnapshotStore is currently tested with 3 backends, MariaDB, MySQL and Postgres.
 


### PR DESCRIPTION
According to https://github.com/prooph/proophessor/issues/38#issuecomment-336200542

- shorter headlines
- introduction instead of using entire README (better overview while browsing through the docs)