### PR TITLE
Don't remove deprecated config option

### DIFF
--- a/src/Container/PdoSnapshotStoreFactory.php
+++ b/src/Container/PdoSnapshotStoreFactory.php
@@ -71,8 +71,6 @@ class PdoSnapshotStoreFactory implements ProvidesDefaultOptions, RequiresConfigI
             if (! isset($config['connection']) && isset($config['connection_service'])) {
                 $config['connection'] = $config['connection_service'];
             }
-
-            unset($config['connection_service']);
         })($config);
 
         $config = $this->options($config, $this->configId);

--- a/tests/Container/PdoSnapshotStoreFactoryTest.php
+++ b/tests/Container/PdoSnapshotStoreFactoryTest.php
@@ -64,6 +64,30 @@ class PdoSnapshotStoreFactoryTest extends TestCase
         $snapshotStore = $factory($container->reveal());
 
         $this->assertInstanceOf(PdoSnapshotStore::class, $snapshotStore);
+        $this->assertArrayHasKey('connection_service', $container->reveal()->get('config')['prooph']['pdo_snapshot_store']['default']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_still_works_with_deprecated_connection_service_key_for_config_objects(): void
+    {
+        $config['prooph']['pdo_snapshot_store']['default'] = [
+            'connection_service' => 'my_connection',
+        ];
+
+        $connection = TestUtil::getConnection();
+
+        $container = $this->prophesize(ContainerInterface::class);
+
+        $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
+        $container->get('config')->willReturn(new \ArrayObject($config))->shouldBeCalled();
+
+        $factory = new PdoSnapshotStoreFactory();
+        $snapshotStore = $factory($container->reveal());
+
+        $this->assertInstanceOf(PdoSnapshotStore::class, $snapshotStore);
+        $this->assertArrayHasKey('connection_service', $container->reveal()->get('config')['prooph']['pdo_snapshot_store']['default']);
     }
 
     /**


### PR DESCRIPTION
@basz @prolic Here is a test case for this.

- https://github.com/prooph/pdo-snapshot-store/issues/19